### PR TITLE
修复对象数组非required时的一个情况

### DIFF
--- a/src/components/formGenerator/formFieldGenerator.vue
+++ b/src/components/formGenerator/formFieldGenerator.vue
@@ -174,6 +174,10 @@ export default class FormFieldGenerator extends Vue {
             newRow[n.field] = n.factory('')
         }
 
+        if (!Array.isArray(this.form[item.field])) {
+            this.form[item.field] = []
+        }
+
         this.form[item.field].push(newRow)
     }
 


### PR DESCRIPTION
如果Item的数组是非required，那它的值可能是null或者不存在，这种情况下写入新行时会遇到错误。
我修改为创建一个新的数组。